### PR TITLE
Adding new dependencies required by latest Chrome version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN apt-get update -qq && \
         libxtst6 \
         lsb-release \
         wget \
-        xdg-utils
+        xdg-utils \
+        libdrm2 \
+        libgbm-dev
 RUN rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 RUN groupadd -r narcissus

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Use Serverless by running `npm run deploy`.
 
 Just run `npm run test` or `make test` to run in a Docker image.
 
+## Calling the API
+
+```
+curl -X GET -H 'X-Api-Key: :key' http://host/?url=:url&selector=:selector
+```
+
 ## TODO
 
 * Compress images


### PR DESCRIPTION
Chrome was failing to start with a couple of errors of type "can't load shared object". Installing two dependencies fixes the errors.